### PR TITLE
test: TestMakeMultiplex use atomic to counter

### DIFF
--- a/functionMultiplexing/multiplexing.go
+++ b/functionMultiplexing/multiplexing.go
@@ -15,6 +15,12 @@ type operator struct {
 	out   chan []reflect.Value
 }
 
+func (op *operator) reset(input interface{}) {
+	op.input = input
+	op.doing = 0
+	op.out = make(chan []reflect.Value)
+}
+
 var OpPool = sync.Pool{
 	New: func() interface{} {
 		return &operator{}
@@ -67,9 +73,7 @@ func todo(fromFunc *reflect.Value) func([]reflect.Value) []reflect.Value {
 		op := m[inputKey]
 		if op == nil {
 			op = OpPool.Get().(*operator)
-			op.input = inputKey
-			op.doing = 0
-			op.out = make(chan []reflect.Value)
+			op.reset(inputKey)
 			m[inputKey] = op
 		}
 		lock.Unlock()

--- a/functionMultiplexing/multiplexing_test.go
+++ b/functionMultiplexing/multiplexing_test.go
@@ -2,17 +2,18 @@ package functionMultiplexing
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
 func TestMakeMultiplex(t *testing.T) {
 	var (
-		callCount = 1000
-		called    = 0
+		callCount = int64(1000)
+		called    = int64(0)
 	)
 
 	from := func(id int) int {
-		called++
+		atomic.AddInt64(&called, 1)
 		return 1
 	}
 	var wrapper func(int) int
@@ -22,7 +23,7 @@ func TestMakeMultiplex(t *testing.T) {
 	}
 
 	wg := sync.WaitGroup{}
-	for i := 0; i < callCount; i++ {
+	for i := int64(0); i < callCount; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
测试函数的计数器改为 atomic，不然错误情况下测试不准确